### PR TITLE
Make installation instructions more discoverable

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,4 +1,6 @@
-The ka9q-radio package is primarily designed for Debian Linux,
+# Installing ka9q-sdr
+
+The ka9q-sdr package is primarily designed for Debian Linux,
 including the Raspbian variant for the Raspberry Pi.
 
 Most but not all of the programs will also build and run on Mac OSX,
@@ -11,19 +13,22 @@ other programs use the portaudio19 shim. I plan to migrate 'funcube'
 to portaudio, but it also sends commands to the dongle with a Linux
 USB library that might not port to OSX.
 
-The ka9q-radio package has several package dependencies beyond those
+The ka9q-sdr package has several package dependencies beyond those
 usually needed to compile C programs (e.g., make, gcc).
+
+## Raspbian, Debian or Ubuntu
 
 On Raspbian, Debian or Ubuntu Linux, run the following command (as root):
 
-apt install libfftw3-dev libbsd-dev libopus-dev libusb-1.0-0-dev libasound2-dev libncursesw5-dev libattr1-dev portaudio19-dev
-
-
+```
+apt install libfftw3-dev libbsd-dev libopus-dev libusb-1.0-0-dev libasound2-dev libncursesw5-dev libattr1-dev portaudio19-dev libncurses5-dev
+```
 
 Some versions of Ubuntu have an older version of libfftw3-dev that lacks full
 thread safety. The symptom here is the missing link-time symbol
-
-       fftwf_make_planner_thread_safe()
+```
+fftwf_make_planner_thread_safe()
+```
 
 If necessary, you can install and build it from the upstream source at
 
@@ -31,15 +36,16 @@ If necessary, you can install and build it from the upstream source at
 
 (Thanks PY2SDR)
 
+## macOS
 
-
-
-On Mac OSX, you'll need Apple's Xcode developer package with the command
+On macOS, you'll need Apple's Xcode developer package with the command
 line tools and the third-party 'macports' package, https://www.macports.org.
 
 Then run, as root:
 
+```
 port install fftw-3 libopus portaudio
+```
 
 I haven't set up virgin systems to test the installs so I could easily have missed something. If so, please let me know.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ The ka9q-radio modules execute from the command line on either Linux
 or OSX.  As yet there is no fancy graphical user interface. (This may
 come later, especially if someone volunteers to create one).
 
+## License
+The License for this software is GPL3, as detailed [here](LICENSE).
+
+
+## Installation
+Installation instructions are [here](INSTALLING.md).
+
 ## Multicasting and the Real Time Protocol (RTP)
 
 The ka9q-radio modules are designed for maximum versatility.  Unlike


### PR DESCRIPTION
Renamed "dependencies" to "INSTALLING.md", added a little markdown and added links in the README.md file. 

This should also address issue #2.