### PR TITLE
Don't delete txt files on make clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# editor debris
+*~
+.#*
+._*
+.*.sw?
+# OS debris
+.DS_Store
+# things are built in the same dir
+*.o
+*.a
+aprs
+aprsfeed
+iqrecord
+opus
+iqplay
+funcube
+monitor
+modulate
+packet
+radio
+pcmsend
+opussend

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -24,7 +24,7 @@ On Raspbian, Debian or Ubuntu Linux, run the following command (as root):
 apt install build-essential libfftw3-dev libbsd-dev libopus-dev libusb-1.0-0-dev \
     libasound2-dev libncursesw5-dev libattr1-dev portaudio19-dev libncurses5-dev
 ```
-This is know to work on Ubuntu 18.04 LTS and Debian 9 (Stretch). It will *not* work 
+This is known to work on Ubuntu 18.04 LTS and Debian 9 (Stretch). It will *not* work 
 with Ubuntu 14.04 LTS, Ubuntu 16.04 LTS or Debian 8 (Jessie). The reason is that 
 ka9q-sdr requires at least version 3.3.5 of libfftw3-dev, and these distributions 
 use an older version. The symptom here is that at link-time, the symbol 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install: all
 	install -D --target-directory=$(LIBDIR) $(AFILES)
 
 clean:
-	rm -f *.o *.a $(EXECS) $(AFILES)
+	rm -f *.o *.a $(EXECS)
 
 .PHONY: clean all
 


### PR DESCRIPTION
The Makefile should not delete the *.txt files on `make clean` (or subsequent builds will fail).

Additionally:

- add gitignore to ignore build artifacts
- fix installation doc typo
